### PR TITLE
Remove catalogs package for now.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -67,7 +67,7 @@ dependencies:
   # xpdan
   - xraylarch>=0.9.45
   - pip:
-  # - edrixs
-    - https://github.com/NSLS-II/nsls2-catalogs/archive/v0.0.1.tar.gz
+    # - edrixs
+    #  - https://github.com/NSLS-II/nsls2-catalogs/archive/v0.0.1.tar.gz
     - mimesis
     - pyzbar


### PR DESCRIPTION
I briefly deployed this at SDCC, but attempting to access a CSX header raised
as follows. Are the YAML files included in this source distribution?


```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-2-4f68dbd443e8> in <module>
----> 1 header = db[128868]

/srv/conda/envs/notebook/lib/python3.7/site-packages/databroker/v1.py in __getitem__(self, key)
    323             return [self[index]
    324                     for index in reversed(range(key.start, key.stop or 0, key.step or 1))]
--> 325         entry = self._catalog[key]
    326         return Header(entry)
    327 

/srv/conda/envs/notebook/lib/python3.7/site-packages/intake/catalog/entry.py in __getitem__(self, item)
    145             else:
    146                 item = item[0]
--> 147         return self._get_default_source()[item]
    148 
    149     def __repr__(self):

/srv/conda/envs/notebook/lib/python3.7/site-packages/intake/catalog/entry.py in _get_default_source(self)
     91         """Instantiate DataSource with default agruments"""
     92         if self._default_source is None:
---> 93             self._default_source = self()
     94         return self._default_source
     95 

/srv/conda/envs/notebook/lib/python3.7/site-packages/intake/catalog/entry.py in __call__(self, persist, **kwargs)
     76             raise ValueError('Persist value (%s) not understood' % persist)
     77         persist = persist or self._pmode
---> 78         s = self.get(**kwargs)
     79         if s.has_been_persisted and persist is not 'never':
     80             s2 = s.get_persisted()

/srv/conda/envs/notebook/lib/python3.7/site-packages/intake/catalog/local.py in get(self)
    811     def get(self):
    812         """Instantiate the DataSource for the given parameters"""
--> 813         return self._entrypoint.load()
    814 
    815 

/srv/conda/envs/notebook/lib/python3.7/site-packages/entrypoints.py in load(self)
     80         """Load the object to which this entry point refers.
     81         """
---> 82         mod = import_module(self.module_name)
     83         obj = mod
     84         if self.object_name:

/srv/conda/envs/notebook/lib/python3.7/importlib/__init__.py in import_module(name, package)
    125                 break
    126             level += 1
--> 127     return _bootstrap._gcd_import(name[level:], package, level)
    128 
    129 

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _gcd_import(name, package, level)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _find_and_load(name, import_)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _call_with_frames_removed(f, *args, **kwds)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _gcd_import(name, package, level)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _find_and_load(name, import_)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _load_unlocked(spec)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap_external.py in exec_module(self, module)

/srv/conda/envs/notebook/lib/python3.7/importlib/_bootstrap.py in _call_with_frames_removed(f, *args, **kwds)

/srv/conda/envs/notebook/lib/python3.7/site-packages/nsls2_catalogs/csx/__init__.py in <module>
      4 
      5 name = 'csx'
----> 6 v0_catalog = Broker.from_config(load_config(f'{name}/{name}.yml'))
      7 v1_catalog = from_config(load_config(f'{name}/{name}.yml'))
      8 catalog = from_config(load_config(f'{name}/{name}.yml')).v2

/srv/conda/envs/notebook/lib/python3.7/site-packages/nsls2_catalogs/__init__.py in load_config(filename)
     18     package_directory = os.path.dirname(os.path.abspath(__file__))
     19     filename = os.path.join(package_directory, filename)
---> 20     with open(filename) as f:
     21         return yaml.load(f, Loader=getattr(yaml, 'FullLoader', yaml.Loader))
     22 

FileNotFoundError: [Errno 2] No such file or directory: '/srv/conda/envs/notebook/lib/python3.7/site-packages/nsls2_catalogs/csx/csx.yml'
```