### PR TITLE
Add pychx package

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -45,6 +45,7 @@ dependencies:
   - py-xgboost
   - py4xs
   - pyarrow
+  - pychx
   - pyfai
   - pypdf2
   - pystackreg


### PR DESCRIPTION
Add a missing `pychx` package that was packaged recently via https://github.com/nsls-ii-forge/pychx-feedstock/pull/1.

attn @tankonst