### PR TITLE
Add `shadow3`, `srwpy`, `edrixs`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -69,8 +69,10 @@ dependencies:
   - scikit-learn
   - scipy>=1.9
   - seaborn
+  - shadow3
   - sip
   - sixtools>=0.0.2
+  - srwpy
   - tiled>=0.1.0a70
   - tornado
   - tzlocal <3  # tzlocal 3 broke API on Python 3.7 and the fix turned into a rabbithole

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - dask-ml
   - dask-xgboost
   - databroker>=2.0.0b8
+  - edrixs
   - eiger-io
   - fabio
   - graphviz


### PR DESCRIPTION
NSLS-II TES users (@bnash and @nickgoldring) requested access to the Shadow3 and SRW codes in Jupyter to perform a comparison of the simulated data with the experimental one. This PR adds both packages.

I sorted the dependencies and removed duplicates (3 `scikit-learn` - was it meant to have `scikit-beam`?)

**Update on 2022-09-15**: added recently built `edrixs` to check if it builds without any conflicts. The build was successful.