### PR TITLE
Pin down JupyterLab

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hvplot
   - hxntools
   - ipympl
-  - jupyterlab=3.3.*
+  - jupyterlab=3.2.*
   - line_profiler
   - lixtools
   - lmfit>=0.9.9

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - hvplot
   - hxntools
   - ipympl
-  - jupyterlab=3.*
+  - jupyterlab=3.3.*
   - line_profiler
   - lixtools
   - lmfit>=0.9.9

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Install manually with pip until conda-forge package is ready.
-git clone --single-branch --branch v0.1.0a60 https://github.com/bluesky/tiled.git /tmp/tiled
+git clone --single-branch --branch v0.1.0a61 https://github.com/bluesky/tiled.git /tmp/tiled
 pip install '/tmp/tiled[complete]'


### PR DESCRIPTION
This is an attempt to fix the 403 issue which appeared around the same time as the JupyterLab 3.3.* release reached the floor.