### PR TITLE
pin edrixs>=0.0.8

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -45,6 +45,7 @@ dependencies:
   - numba
   - numexpr
   - numpy>=1.22
+  - openmpi>=4.1.4
   - pandas
   - papermill
   - periodictable

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - dask-ml
   - dask-xgboost
   - databroker>=2.0.0b10
-  - edrixs>=0.08
+  - edrixs>=0.0.8
   - eiger-io
   - fabio
   - graphviz

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - dask-ml
   - dask-xgboost
   - databroker>=2.0.0b10
-  - edrixs
+  - edrixs>=0.08
   - eiger-io
   - fabio
   - graphviz
@@ -85,4 +85,3 @@ dependencies:
     - mimesis
     - pyzbar
     - smi_analysis
-  


### PR DESCRIPTION
The current edrixs installation on JupyterHub is not fully functional -- see below. I presume this update will fix it?

Or maybe we need to fix a more recent open-mpi package?

@mrakitin can you advise?

```
openmpi>=4.1.4
```
This is the error from the default JupyterHub installation:
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 from mpi4py import MPI

ImportError: libmpi.so.12: cannot open shared object file: No such file or directory
```