### PR TITLE
Install `smi-analysis` and `pyfai` from git repos

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -57,7 +57,7 @@ dependencies:
   - pyarrow
   - pycentroids
   - pychx >=4.1.2
-  - pyfai
+  # - pyfai
   - pymongo
   - pypdf2
   - pystackreg
@@ -86,4 +86,5 @@ dependencies:
   - pip:
     - mimesis
     - pyzbar
-    - smi_analysis
+    - git+https://github.com/silx-kit/pyFAI.git
+    - git+https://github.com/NSLS-II-SMI/smi-analysis.git


### PR DESCRIPTION
Requested by @gfreychet.

xref https://github.com/NSLS-II-SMI/smi-analysis/pull/11/files#diff-e285c1b9901cd202e89d9f37e3249a6fee524a65428895e1a45fd062cc0f9aca