### PR TITLE
Install SMI packages from conda-forge

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -38,7 +38,7 @@ dependencies:
   - nbclassic>=0.2.8
   - nbgitpuller
   - nbserverproxy
-    # - netcdf4  # jams up the solver, and unclear whether it is actually used
+  # - netcdf4  # jams up the solver, and unclear whether it is actually used
   - nbconvert-webpdf
   - nodejs
   - notebook
@@ -57,7 +57,7 @@ dependencies:
   - pyarrow
   - pycentroids
   - pychx >=4.1.2
-  # - pyfai
+  - pyfai
   - pymongo
   - pypdf2
   - pystackreg
@@ -75,6 +75,7 @@ dependencies:
   - shadow3
   - sip
   - sixtools>=0.0.2
+  - smi-analysis>=0.2.0
   - srwpy
   - tiled>=0.1.0a74
   - tornado
@@ -86,5 +87,3 @@ dependencies:
   - pip:
     - mimesis
     - pyzbar
-    - git+https://github.com/silx-kit/pyFAI.git
-    - git+https://github.com/NSLS-II-SMI/smi-analysis.git


### PR DESCRIPTION
A follow-up PR for #53 with conda-forge packages:
- https://github.com/conda-forge/pygix-feedstock/pull/4
- https://github.com/conda-forge/smi-analysis-feedstock/pull/1: supports both newer (and unreleased yet) and older pyFAI.