### PR TITLE
Add neovim to apt packages

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -7,6 +7,7 @@ ffmpeg
 graphviz
 pandoc
 vim
+neovim
 texlive-xetex
 texlive-fonts-recommended
 texlive-plain-generic


### PR DESCRIPTION
Small package addition to enable some more advanced vim features (like Github Copilot).