### PR TITLE
Updated environment.yml to include scipp

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -72,6 +72,7 @@ dependencies:
   - requests
   - sasview
   - scikit-learn
+  - scipp
   - scipy>=1.9
   - seaborn
   - shadow3


### PR DESCRIPTION
CHX will attempt to use scipp to manage data from our new, photon-counting Timepix3 detector.