### PR TITLE
add digautoprofiler to environment.yml

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -91,3 +91,4 @@ dependencies:
     - mimesis
     - pyzbar
     - pyhyperscattering[all]
+    - digautoprofiler


### PR DESCRIPTION
Hi,

We would like to add the `digautoprofiler` library to the jupyterhub.

This adds a jupyterlab extension, AutoProfiler, that helps users visualize their data with an interactive visualization sidebar. More information is in our github: https://github.com/cmudig/AutoProfiler

I am the developer of this package and would be happy to answer any questions about it (email: willepp@cmu.edu). Our group at CMU has been working with Wei Xu at BNL on this project.