### PR TITLE
MNT: temporarily pin numpy back to unbreak modestimage

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - nslsii
   - numba
   - numexpr
-  - numpy>=1.22
+  - numpy>=1.22,<1.24.0
   - openmpi>=4.1.4
   - pandas
   - papermill


### PR DESCRIPTION
working on fixing modest image, short-term fix.