### PR TITLE
Pin notebook back for compat

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,6 +9,6 @@ dependencies:
   - nbgitpuller
   - nbconvert-webpdf
   - nodejs
-  - notebook
+  - notebook<7  # pinned for compat with jupyterhub-singleuser 1.3
   - pip  # mamba warns us to explicitly list this dependency
   - voila


### PR DESCRIPTION
Working around

```
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/jupyterhub-singleuser", line 7, in <module>
    from jupyterhub.singleuser import main
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/jupyterhub/singleuser/__init__.py", line 5, in <module>
    from .app import main
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/jupyterhub/singleuser/app.py", line 16, in <module>
    App = import_item(JUPYTERHUB_SINGLEUSER_APP)
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/traitlets/utils/importstring.py", line 30, in import_item
    module = __import__(package, fromlist=[obj])
ModuleNotFoundError: No module named 'notebook.notebookapp'
```