### PR TITLE
Replace python3 kernel.

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,5 +3,4 @@
 # Replace the default Python 3 kernel, which would use the Jupyter server
 # environment, with one that points into /nsls2/conda/ which is expected
 # to be mounted in when the container is run.
-mv /srv/conda/envs/notebook/share/jupyter/kernels/python3 /srv/conda/envs/notebook/share/jupyter/kernels/external_python3
-mv ./binder/kernel.json /srv/conda/envs/notebook/share/jupyter/kernels/external_python3/kernel.json
+cp ./binder/kernel.json /srv/conda/envs/notebook/share/jupyter/kernels/python3/kernel.json


### PR DESCRIPTION
The original `python3` kernel was still lingering. I intended my approach to be lesson confusing, but I think it was actually more confusing.