### PR TITLE
Add ipympl.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - python=3.9
   - dask-labextension
+  - ipympl  # needed for jupyter-matplotlib JS side
   - jupyter-server-proxy
   - jupyter_server=1.23.6  # known working with old jupyterhub-singleuser
   - jupyterhub-singleuser=1.3.0  # match JupyterHub deployment version


### PR DESCRIPTION
This causes the JS side (`jupyter-matplotlib`) to be installed, and may be needed now.