### PR TITLE
Pin jupyterlab h5web

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - jupyter-server-proxy
   - jupyter_server=1.23.6  # known working with old jupyterhub-singleuser
   - jupyterhub-singleuser=1.3.0  # match JupyterHub deployment version
-  - jupyterlab-h5web=8.*
+  - jupyterlab-h5web=8.*  # pinned to 8 while jupyterlab=3 is used
   - jupyterlab=3.*
   - nbconvert-webpdf
   - nbgitpuller

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - jupyter-server-proxy
   - jupyter_server=1.23.6  # known working with old jupyterhub-singleuser
   - jupyterhub-singleuser=1.3.0  # match JupyterHub deployment version
-  - jupyterlab-h5web
+  - jupyterlab-h5web=8.*
   - jupyterlab=3.*
   - nbconvert-webpdf
   - nbgitpuller


### PR DESCRIPTION
Keep jupyterlab-h5web at version 8 (highest version compatible with jupyterlab 3). Added a comment in the environment.yml file indicating the reason for this pinning as well.