### PR TITLE
Add ipyaggrid extension to server

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - notebook<7  # pinned for compat with jupyterhub-singleuser 1.3
   - pip  # mamba warns us to explicitly list this dependency
   - voila
+  - ipyaggrid


### PR DESCRIPTION
Adds the ipyaggrid extension to the server environment to support embedded AGgrid tables in notebooks.