### PR TITLE
Hdf5 compression plugins for h5web

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,9 @@ dependencies:
   - jupyter_server=1.23.6  # known working with old jupyterhub-singleuser
   - jupyterhub-singleuser=1.3.0  # match JupyterHub deployment version
   - jupyterlab-h5web=8.*  # pinned to 8 while jupyterlab=3 is used
+  - hdf5-external-filter-plugins-bitshuffle
+  - hdf5-external-filter-plugins-lz4
+  - blosc-hdf5-plugin
   - jupyterlab=3.*
   - nbconvert-webpdf
   - nbgitpuller

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,8 +8,7 @@ dependencies:
   - jupyter_server=1.23.6  # known working with old jupyterhub-singleuser
   - jupyterhub-singleuser=1.3.0  # match JupyterHub deployment version
   - jupyterlab-h5web=8.*  # pinned to 8 while jupyterlab=3 is used
-  - hdf5-external-filter-plugins-bitshuffle
-  - hdf5-external-filter-plugins-lz4
+  - hdf5-external-filter-plugins
   - blosc-hdf5-plugin
   - jupyterlab=3.*
   - nbconvert-webpdf


### PR DESCRIPTION
 * add blosc because that does not appear to be built into the hdf5-external-filter-plugins packages
 * also add the more standard bs, lz4, bz2 that will be useful for viewing data from many detectors